### PR TITLE
update overlay to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER John Regan <john@jrjrtech.com>
 
 COPY rootfs /
 
-ADD https://github.com/just-containers/s6-overlay/releases/download/v1.11.0.1/s6-overlay-amd64.tar.gz /tmp/s6-overlay.tar.gz
+ADD https://github.com/just-containers/s6-overlay/releases/download/v1.11.0.2/s6-overlay-amd64.tar.gz /tmp/s6-overlay.tar.gz
 RUN tar xvfz /tmp/s6-overlay.tar.gz -C /
 
 ENTRYPOINT ["/init"]


### PR DESCRIPTION
it fixes an issue with catchall logger, now it works as expected.
