### PR TITLE
Exclude archive from image history

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,11 @@ MAINTAINER John Regan <john@jrjrtech.com>
 COPY rootfs /
 
 # s6 overlay
-ADD https://github.com/just-containers/s6-overlay/releases/download/v1.17.1.1/s6-overlay-amd64.tar.gz /tmp/s6-overlay.tar.gz
-RUN tar xvfz /tmp/s6-overlay.tar.gz -C /
+RUN apk add --no-cache wget \
+ && wget https://github.com/just-containers/s6-overlay/releases/download/v1.17.1.1/s6-overlay-amd64.tar.gz --no-check-certificate -O /tmp/s6-overlay.tar.gz \
+ && tar xvfz /tmp/s6-overlay.tar.gz -C / \
+ && rm -f /tmp/s6-overlay.tar.gz \
+ && apk del wget
 
 ##
 ## INIT


### PR DESCRIPTION
This prevents `/tmp/s6-overlay.tar.gz` from being saved among the image layers, which in turn shaves 1.42 MB off the size of the image.

Before: 10.63 MB
After: 9.209 MB
