### PR TITLE
Use curl instead of wget, bump s6 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,10 @@ MAINTAINER John Regan <john@jrjrtech.com>
 COPY rootfs /
 
 # s6 overlay
-RUN apk add --no-cache wget \
- && wget https://github.com/just-containers/s6-overlay/releases/download/v1.18.1.3/s6-overlay-amd64.tar.gz --no-check-certificate -O /tmp/s6-overlay.tar.gz \
- && tar xvfz /tmp/s6-overlay.tar.gz -C / \
- && rm -f /tmp/s6-overlay.tar.gz \
- && apk del wget
+RUN apk add --no-cache curl \
+ && curl -L -s https://github.com/just-containers/s6-overlay/releases/download/v1.18.1.5/s6-overlay-amd64.tar.gz \
+  | tar xvzf - -C / \
+ && apk del --no-cache curl
 
 ##
 ## INIT


### PR DESCRIPTION
Use curl | tar instead of wget. Verifies the certificate for a secure download.

Bump s6 overlay to 1.18.1.5.
